### PR TITLE
fix NULL 0 count(): Argument #1 ($value) must be of type Countable|ar…

### DIFF
--- a/src/packages/jbuniversal/jbuniversal/framework/classes/cart/jbvariantlist.php
+++ b/src/packages/jbuniversal/jbuniversal/framework/classes/cart/jbvariantlist.php
@@ -227,8 +227,13 @@ class JBCartVariantList extends ArrayObject
     #[\ReturnTypeWillChange]
     public function count(): int
     {
+        if ($this->variants === null) {
+            return 0;
+        }
+    
         return count($this->variants);
     }
+    
 
     /**
      * @param $key


### PR DESCRIPTION
…ray,

FIX: 0 count(): Argument #1 ($value) must be of type Countable|array,

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/JBZoo/JBZoo) and create your branch from `develop`.
2. Run `make` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`make test`).
5. If you haven't already, complete the CLA.
